### PR TITLE
Merge dev

### DIFF
--- a/attrs/common.go
+++ b/attrs/common.go
@@ -170,7 +170,12 @@ func (a *Aggregator) Unmarshal(buf []byte, cps caps.Caps, dir dir.Dir) error {
 		asnlen = 4
 	}
 
-	if len(buf) != asnlen+4 {
+	for len(buf) != asnlen+4 {
+		// can retry with 2-byte ASNs?
+		if asnlen == 4 && a.Code() == ATTR_AGGREGATOR && cps.Has(caps.CAP_AS_GUESS) {
+			asnlen = 2
+			continue
+		}
 		return ErrLength
 	}
 

--- a/caps/cap.go
+++ b/caps/cap.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Code represents BGP capability code
-type Code byte
+type Code uint16
 
 // capability codes
 const (
@@ -33,6 +33,8 @@ const (
 	CAP_BFD                    Code = 74
 	CAP_VERSION                Code = 75
 	CAP_PRE_ROUTE_REFRESH      Code = 128
+
+	CAP_AS_GUESS Code = 0xff + 1 // pseudo-capability: guess ASN size
 )
 
 //go:generate go run github.com/dmarkham/enumer -type=Code -trimprefix CAP_


### PR DESCRIPTION
This PR merges development changes that add ASN size guessing capability and improve error handling for BGP attribute parsing. The changes introduce a pseudo-capability mechanism to enable automatic fallback from 4-byte to 2-byte ASN parsing when mismatches are detected.

Key Changes:
- Added CAP_AS_GUESS pseudo-capability (value 0x100) to enable ASN size fallback logic
- Implemented retry mechanisms in AS_PATH and Aggregator attribute parsers to handle ASN size mismatches
- Added new ObjectPaths function for JSON path-based object traversal with error recovery
