### PR TITLE
filter: add json, attr, time, dir, seq filters and fix != semantics

### DIFF
--- a/attrs/aspath.go
+++ b/attrs/aspath.go
@@ -60,6 +60,29 @@ func (a *Aspath) Len() int {
 	return l
 }
 
+// UniqueLen returns the number of unique consecutive ASNs in the AS_PATH,
+// ignoring prepending (consecutive duplicate ASNs count as 1).
+// AS_SETs with more than 1 member always count as 1 hop.
+func (a *Aspath) UniqueLen() (l int) {
+	var prev uint32
+	first := true
+	for _, seg := range a.Segments {
+		if seg.IsSet && len(seg.List) > 1 {
+			l++
+			first = true // reset dedup after a set
+		} else {
+			for _, asn := range seg.List {
+				if first || asn != prev {
+					l++
+					prev = asn
+					first = false
+				}
+			}
+		}
+	}
+	return l
+}
+
 // Hops returns an iterator over the AS_PATH hops.
 // Each hop is either a single ASN (len=1) or a list of AS_SET members (len>1).
 func (a *Aspath) Hops() iter.Seq2[int, []uint32] {

--- a/filter/af.go
+++ b/filter/af.go
@@ -54,16 +54,16 @@ func (e *Expr) afParse() error {
 	return nil
 }
 
-func (e *Expr) afEval(ev *Eval) bool {
+func (e *Expr) afEval(ev *Eval) Res {
 	as := ev.Msg.Update.AfiSafi()
 
 	switch v := e.Val.(type) {
 	case afi.AFI:
-		return as.Afi() == v
+		return resBool(as.Afi() == v)
 	case afi.SAFI:
-		return as.Safi() == v
+		return resBool(as.Safi() == v)
 	case afi.AS:
-		return as == v
+		return resBool(as == v)
 	}
 
 	panic("unreachable")

--- a/filter/aspath.go
+++ b/filter/aspath.go
@@ -10,7 +10,7 @@ func (e *Expr) aspathLenParse() error {
 	if e.Idx != nil {
 		return ErrIndex
 	}
-	if e.Op == OP_TRUE {
+	if e.Op == OP_PRESENT {
 		return nil
 	}
 	if e.Op == OP_LIKE {
@@ -23,54 +23,54 @@ func (e *Expr) aspathLenParse() error {
 	return nil
 }
 
-func (e *Expr) aspathLenEval(ev *Eval) bool {
+func (e *Expr) aspathLenEval(ev *Eval) Res {
 	aspath := ev.Msg.Update.AsPath()
 	if aspath == nil {
-		return false
+		return RES_ABSENT
 	}
-	if e.Op == OP_TRUE {
-		return aspath.Len() > 0
+	if e.Op == OP_PRESENT {
+		return resBool(aspath.Len() > 0)
 	}
 	length := aspath.Len()
 	ref := e.Val.(int)
 	switch e.Op {
 	case OP_EQ:
-		return length == ref
+		return resBool(length == ref)
 	case OP_LT:
-		return length < ref
+		return resBool(length < ref)
 	case OP_LE:
-		return length <= ref
+		return resBool(length <= ref)
 	case OP_GT:
-		return length > ref
+		return resBool(length > ref)
 	case OP_GE:
-		return length >= ref
+		return resBool(length >= ref)
 	}
-	return false
+	return RES_FALSE
 }
 
-func (e *Expr) aspathHopsEval(ev *Eval) bool {
+func (e *Expr) aspathHopsEval(ev *Eval) Res {
 	aspath := ev.Msg.Update.AsPath()
 	if aspath == nil {
-		return false
+		return RES_ABSENT
 	}
-	if e.Op == OP_TRUE {
-		return aspath.UniqueLen() > 0
+	if e.Op == OP_PRESENT {
+		return resBool(aspath.UniqueLen() > 0)
 	}
 	length := aspath.UniqueLen()
 	ref := e.Val.(int)
 	switch e.Op {
 	case OP_EQ:
-		return length == ref
+		return resBool(length == ref)
 	case OP_LT:
-		return length < ref
+		return resBool(length < ref)
 	case OP_LE:
-		return length <= ref
+		return resBool(length <= ref)
 	case OP_GT:
-		return length > ref
+		return resBool(length > ref)
 	case OP_GE:
-		return length >= ref
+		return resBool(length >= ref)
 	}
-	return false
+	return RES_FALSE
 }
 
 func (e *Expr) aspathParse() error {
@@ -78,7 +78,7 @@ func (e *Expr) aspathParse() error {
 	ok := false
 	can_index := false
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		ok = true // = non-empty AS_PATH
 	case OP_EQ:
 		switch v := e.Val.(type) {
@@ -136,11 +136,10 @@ func (e *Expr) aspathParse() error {
 	return nil
 }
 
-func (e *Expr) aspathEval(ev *Eval) bool {
-	// has valid, non-empty AS_PATH?
+func (e *Expr) aspathEval(ev *Eval) Res {
 	aspath := ev.Msg.Update.AsPath()
 	if aspath == nil {
-		return false
+		return RES_ABSENT
 	}
 
 	// to_text converts aspath to JSON without the brackets
@@ -179,14 +178,14 @@ func (e *Expr) aspathEval(ev *Eval) bool {
 	}
 
 	switch e.Op {
-	case OP_TRUE:
-		return true // already checked
+	case OP_PRESENT:
+		return RES_TRUE // already checked
 	case OP_LIKE:
 		re := e.Val.(*regexp.Regexp)
-		return re.Match(to_text())
+		return resBool(re.Match(to_text()))
 	case OP_EQ:
 		if v, ok := e.Val.([]byte); ok {
-			return bytes.Equal(v, to_text())
+			return resBool(bytes.Equal(v, to_text()))
 		}
 		fallthrough
 	default:
@@ -195,15 +194,15 @@ func (e *Expr) aspathEval(ev *Eval) bool {
 		// investigate given index only?
 		if e.Idx != nil {
 			index := e.Idx.(int)
-			return check_hop(ref, aspath.Hop(index))
+			return resBool(check_hop(ref, aspath.Hop(index)))
 		}
 
 		// any hop match is ok
 		for _, hop := range aspath.Hops() {
 			if check_hop(ref, hop) {
-				return true
+				return RES_TRUE
 			}
 		}
-		return false
+		return RES_FALSE
 	}
 }

--- a/filter/aspath.go
+++ b/filter/aspath.go
@@ -48,6 +48,31 @@ func (e *Expr) aspathLenEval(ev *Eval) bool {
 	return false
 }
 
+func (e *Expr) aspathHopsEval(ev *Eval) bool {
+	aspath := ev.Msg.Update.AsPath()
+	if aspath == nil {
+		return false
+	}
+	if e.Op == OP_TRUE {
+		return aspath.UniqueLen() > 0
+	}
+	length := aspath.UniqueLen()
+	ref := e.Val.(int)
+	switch e.Op {
+	case OP_EQ:
+		return length == ref
+	case OP_LT:
+		return length < ref
+	case OP_LE:
+		return length <= ref
+	case OP_GT:
+		return length > ref
+	case OP_GE:
+		return length >= ref
+	}
+	return false
+}
+
 func (e *Expr) aspathParse() error {
 	// verify the operator and value
 	ok := false
@@ -97,9 +122,11 @@ func (e *Expr) aspathParse() error {
 		return fmt.Errorf("invalid value: %v", e.Val)
 	}
 
-	// check if index is allowed and is an integer
+	// check if index is allowed and is an integer (or "*" which means any)
 	if e.Idx != nil {
-		if !can_index {
+		if e.Idx == "*" {
+			e.Idx = nil // [*] = any hop, same as no index
+		} else if !can_index {
 			return fmt.Errorf("index not allowed: %v", e.Idx)
 		} else if _, ok := e.Idx.(int); !ok {
 			return fmt.Errorf("invalid index: %v", e.Idx)
@@ -171,7 +198,7 @@ func (e *Expr) aspathEval(ev *Eval) bool {
 			return check_hop(ref, aspath.Hop(index))
 		}
 
-		// any index match is ok
+		// any hop match is ok
 		for _, hop := range aspath.Hops() {
 			if check_hop(ref, hop) {
 				return true

--- a/filter/community.go
+++ b/filter/community.go
@@ -16,7 +16,7 @@ func (e *Expr) communityParse() error {
 
 	// check operator
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		e.Val = nil
 	case OP_EQ:
 		// make e.Val a JSON array
@@ -62,29 +62,29 @@ func (e *Expr) communityParse() error {
 	return nil
 }
 
-func (e *Expr) communityEval(ev *Eval) bool {
+func (e *Expr) communityEval(ev *Eval) Res {
 	upd := &ev.Msg.Update
 
-	// handle OP_TRUE / OP_EQ, prepare for OP_LIKE otherwise
 	var json []byte
 	switch e.Attr {
 	case ATTR_COMM:
 		com := upd.Community()
 		if com.Len() == 0 {
-			return false
+			return RES_ABSENT
+		}
+		if e.Op == OP_PRESENT {
+			return RES_TRUE
 		}
 		switch e.Op {
-		case OP_TRUE:
-			return true
 		case OP_EQ:
 			ref := e.Val.(attrs.Community)
 			asn, val := ref.ASN[0], ref.Value[0]
 			for i := range com.ASN {
 				if com.ASN[i] == asn && com.Value[i] == val {
-					return true // found a match
+					return RES_TRUE
 				}
 			}
-			return false // no match
+			return RES_FALSE
 		default:
 			json = com.ToJSON(json)
 		}
@@ -92,20 +92,21 @@ func (e *Expr) communityEval(ev *Eval) bool {
 	case ATTR_COMM_EXT:
 		com := upd.ExtCommunity()
 		if com.Len() == 0 {
-			return false
+			return RES_ABSENT
+		}
+		if e.Op == OP_PRESENT {
+			return RES_TRUE
 		}
 		switch e.Op {
-		case OP_TRUE:
-			return true
 		case OP_EQ:
 			ref := e.Val.(attrs.Extcom)
 			typ, val := ref.Type[0], ref.Value[0].Marshal()
 			for i := range com.Type {
 				if com.Type[i] == typ && com.Value[i].Marshal() == val {
-					return true // found a match
+					return RES_TRUE
 				}
 			}
-			return false // no match
+			return RES_FALSE
 		default:
 			json = com.ToJSON(json)
 		}
@@ -113,20 +114,21 @@ func (e *Expr) communityEval(ev *Eval) bool {
 	case ATTR_COMM_LARGE:
 		com := upd.LargeCommunity()
 		if com.Len() == 0 {
-			return false
+			return RES_ABSENT
+		}
+		if e.Op == OP_PRESENT {
+			return RES_TRUE
 		}
 		switch e.Op {
-		case OP_TRUE:
-			return true
 		case OP_EQ:
 			ref := e.Val.(attrs.LargeCom)
 			asn, val1, val2 := ref.ASN[0], ref.Value1[0], ref.Value2[0]
 			for i := range com.ASN {
 				if com.ASN[i] == asn && com.Value1[i] == val1 && com.Value2[i] == val2 {
-					return true // found a match
+					return RES_TRUE
 				}
 			}
-			return false // no match
+			return RES_FALSE
 		default:
 			json = com.ToJSON(json)
 		}
@@ -134,11 +136,11 @@ func (e *Expr) communityEval(ev *Eval) bool {
 
 	// if we are here, it's an OP_LIKE against JSON of the community values
 	if len(json) <= 2 {
-		return false // empty json
+		return RES_FALSE // empty json
 	} else {
 		json = json[1 : len(json)-1] // remove brackets
 	}
 
 	// run the regex check
-	return e.Val.(*regexp.Regexp).Match(json)
+	return resBool(e.Val.(*regexp.Regexp).Match(json))
 }

--- a/filter/dir.go
+++ b/filter/dir.go
@@ -12,13 +12,13 @@ func (e *Expr) dirParse() error {
 	}
 
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		// ok
 	case OP_EQ:
 		s := fmt.Sprintf("%v", e.Val)
 		d, err := dir.DirString(s)
 		if err != nil {
-			return fmt.Errorf("invalid direction: %s (expected L or R)", s)
+			return fmt.Errorf("invalid direction: %s (expected L, R, or LR)", s)
 		}
 		e.Val = d
 	default:
@@ -29,9 +29,12 @@ func (e *Expr) dirParse() error {
 	return nil
 }
 
-func (e *Expr) dirEval(ev *Eval) bool {
-	if e.Op == OP_TRUE {
-		return ev.Msg.Dir != 0
+func (e *Expr) dirEval(ev *Eval) Res {
+	if ev.Msg.Dir == 0 {
+		return RES_ABSENT
 	}
-	return ev.Msg.Dir == e.Val.(dir.Dir)
+	if e.Op == OP_PRESENT {
+		return RES_TRUE
+	}
+	return resBool(ev.Msg.Dir == e.Val.(dir.Dir))
 }

--- a/filter/dir.go
+++ b/filter/dir.go
@@ -1,0 +1,37 @@
+package filter
+
+import (
+	"fmt"
+
+	"github.com/bgpfix/bgpfix/dir"
+)
+
+func (e *Expr) dirParse() error {
+	if e.Idx != nil {
+		return ErrIndex
+	}
+
+	switch e.Op {
+	case OP_TRUE:
+		// ok
+	case OP_EQ:
+		s := fmt.Sprintf("%v", e.Val)
+		d, err := dir.DirString(s)
+		if err != nil {
+			return fmt.Errorf("invalid direction: %s (expected L or R)", s)
+		}
+		e.Val = d
+	default:
+		return ErrOp
+	}
+
+	e.Types = true
+	return nil
+}
+
+func (e *Expr) dirEval(ev *Eval) bool {
+	if e.Op == OP_TRUE {
+		return ev.Msg.Dir != 0
+	}
+	return ev.Msg.Dir == e.Val.(dir.Dir)
+}

--- a/filter/eval.go
+++ b/filter/eval.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"github.com/bgpfix/bgpfix/caps"
+	bj "github.com/bgpfix/bgpfix/json"
 	"github.com/bgpfix/bgpfix/msg"
 	"github.com/puzpuzpuz/xsync/v4"
 )
@@ -18,6 +19,12 @@ type Eval struct {
 
 	cached int             // msg.Version for which the cache is valid
 	cache  map[string]bool // cached results of evaluated expressions
+
+	// lazy caches for json/time filters
+	upperVer int    // msg.Version for which upperJSON is valid
+	upperJSON []byte // cached upper layer JSON (element [4] of msg JSON)
+	timeVer  int    // msg.Version for which timeFmt is valid
+	timeFmt  string // cached formatted timestamp
 }
 
 // NewEval creates a new Eval instance.
@@ -57,10 +64,91 @@ func (ev *Eval) Set(m *msg.Msg, kv *xsync.Map[string, any], caps caps.Caps, tags
 	return ev
 }
 
-// Clear resets the cache to match the current Msg version.
+// ClearCache resets the cache to match the current Msg version.
 func (ev *Eval) ClearCache() {
 	clear(ev.cache)
 	ev.cached = ev.Msg.Version
+	ev.upperVer = -1
+	ev.timeVer = -1
+}
+
+// getUpper returns the upper layer JSON (element [4] of the message JSON array).
+// Returns nil for messages with null upper layer (eg. KEEPALIVE).
+func (ev *Eval) getUpper() []byte {
+	if ev.upperVer != ev.Msg.Version {
+		ev.upperVer = ev.Msg.Version
+		ev.upperJSON = bj.Get(ev.Msg.GetJSON(), "[4]")
+	}
+	return ev.upperJSON
+}
+
+// getTime returns the formatted timestamp string for the current message.
+func (ev *Eval) getTime() string {
+	if ev.timeVer != ev.Msg.Version {
+		ev.timeVer = ev.Msg.Version
+		ev.timeFmt = ev.Msg.Time.Format(msg.JSON_TIME)
+	}
+	return ev.timeFmt
+}
+
+// attrExists checks whether the attribute referenced by e exists in the message.
+// Used by OpNot (!=, !~) to distinguish "doesn't exist" from "exists but doesn't match".
+func (ev *Eval) attrExists(e *Expr) bool {
+	m := ev.Msg
+	switch e.Attr {
+	case ATTR_EXPR:
+		return true
+	case ATTR_TAG:
+		if e.Idx != nil {
+			return ev.PipeTags[e.Idx.(string)] != ""
+		}
+		return len(ev.PipeTags) > 0
+	case ATTR_TYPE:
+		return true
+	case ATTR_AF:
+		return true
+	case ATTR_REACH:
+		return len(m.Update.AllReach()) > 0
+	case ATTR_UNREACH:
+		return len(m.Update.AllUnreach()) > 0
+	case ATTR_PREFIX:
+		return len(m.Update.AllReach()) > 0 || len(m.Update.AllUnreach()) > 0
+	case ATTR_ASPATH, ATTR_ASPATH_LEN, ATTR_ASPATH_HOPS:
+		return m.Update.AsPath() != nil
+	case ATTR_NEXTHOP:
+		return m.Update.NextHop().IsValid()
+	case ATTR_ORIGIN:
+		_, ok := m.Update.Origin()
+		return ok
+	case ATTR_MED:
+		_, ok := m.Update.Med()
+		return ok
+	case ATTR_LOCALPREF:
+		_, ok := m.Update.LocalPref()
+		return ok
+	case ATTR_COMM:
+		return m.Update.Community().Len() > 0
+	case ATTR_COMM_EXT:
+		return m.Update.ExtCommunity().Len() > 0
+	case ATTR_COMM_LARGE:
+		return m.Update.LargeCommunity().Len() > 0
+	case ATTR_OTC:
+		_, ok := m.Update.Otc()
+		return ok
+	case ATTR_DIR:
+		return m.Dir != 0
+	case ATTR_SEQ:
+		return m.Seq != 0
+	case ATTR_TIME:
+		return !m.Time.IsZero()
+	case ATTR_JSON, ATTR_JSONATTR:
+		upper := ev.getUpper()
+		if upper == nil {
+			return false
+		}
+		return bj.Get(upper, e.Idx.([]string)...) != nil
+	}
+	return false
 }
 
 // Run evaluates given Filter f against the current message.

--- a/filter/eval.go
+++ b/filter/eval.go
@@ -2,7 +2,6 @@ package filter
 
 import (
 	"github.com/bgpfix/bgpfix/caps"
-	bj "github.com/bgpfix/bgpfix/json"
 	"github.com/bgpfix/bgpfix/msg"
 	"github.com/puzpuzpuz/xsync/v4"
 )
@@ -17,14 +16,9 @@ type Eval struct {
 	PipeCaps caps.Caps               // pipe capabilities (can be nil)
 	PipeTags map[string]string       // pipe message tags (can be nil)
 
-	cached int             // msg.Version for which the cache is valid
-	cache  map[string]bool // cached results of evaluated expressions
-
-	// lazy caches for json/time filters
-	upperVer int    // msg.Version for which upperJSON is valid
-	upperJSON []byte // cached upper layer JSON (element [4] of msg JSON)
-	timeVer  int    // msg.Version for which timeFmt is valid
-	timeFmt  string // cached formatted timestamp
+	cached    int            // msg.Version for which the cache is valid
+	cache     map[string]Res // cached results of evaluated expressions
+	cacheTime string         // cached formatted timestamp
 }
 
 // NewEval creates a new Eval instance.
@@ -32,7 +26,7 @@ type Eval struct {
 func NewEval(use_cache bool) *Eval {
 	ev := &Eval{}
 	if use_cache {
-		ev.cache = make(map[string]bool)
+		ev.cache = make(map[string]Res)
 	}
 	return ev
 }
@@ -68,87 +62,15 @@ func (ev *Eval) Set(m *msg.Msg, kv *xsync.Map[string, any], caps caps.Caps, tags
 func (ev *Eval) ClearCache() {
 	clear(ev.cache)
 	ev.cached = ev.Msg.Version
-	ev.upperVer = -1
-	ev.timeVer = -1
-}
-
-// getUpper returns the upper layer JSON (element [4] of the message JSON array).
-// Returns nil for messages with null upper layer (eg. KEEPALIVE).
-func (ev *Eval) getUpper() []byte {
-	if ev.upperVer != ev.Msg.Version {
-		ev.upperVer = ev.Msg.Version
-		ev.upperJSON = bj.Get(ev.Msg.GetJSON(), "[4]")
-	}
-	return ev.upperJSON
+	ev.cacheTime = ""
 }
 
 // getTime returns the formatted timestamp string for the current message.
 func (ev *Eval) getTime() string {
-	if ev.timeVer != ev.Msg.Version {
-		ev.timeVer = ev.Msg.Version
-		ev.timeFmt = ev.Msg.Time.Format(msg.JSON_TIME)
+	if len(ev.cacheTime) == 0 {
+		ev.cacheTime = ev.Msg.Time.Format(msg.JSON_TIME)
 	}
-	return ev.timeFmt
-}
-
-// attrExists checks whether the attribute referenced by e exists in the message.
-// Used by OpNot (!=, !~) to distinguish "doesn't exist" from "exists but doesn't match".
-func (ev *Eval) attrExists(e *Expr) bool {
-	m := ev.Msg
-	switch e.Attr {
-	case ATTR_EXPR:
-		return true
-	case ATTR_TAG:
-		if e.Idx != nil {
-			return ev.PipeTags[e.Idx.(string)] != ""
-		}
-		return len(ev.PipeTags) > 0
-	case ATTR_TYPE:
-		return true
-	case ATTR_AF:
-		return true
-	case ATTR_REACH:
-		return len(m.Update.AllReach()) > 0
-	case ATTR_UNREACH:
-		return len(m.Update.AllUnreach()) > 0
-	case ATTR_PREFIX:
-		return len(m.Update.AllReach()) > 0 || len(m.Update.AllUnreach()) > 0
-	case ATTR_ASPATH, ATTR_ASPATH_LEN, ATTR_ASPATH_HOPS:
-		return m.Update.AsPath() != nil
-	case ATTR_NEXTHOP:
-		return m.Update.NextHop().IsValid()
-	case ATTR_ORIGIN:
-		_, ok := m.Update.Origin()
-		return ok
-	case ATTR_MED:
-		_, ok := m.Update.Med()
-		return ok
-	case ATTR_LOCALPREF:
-		_, ok := m.Update.LocalPref()
-		return ok
-	case ATTR_COMM:
-		return m.Update.Community().Len() > 0
-	case ATTR_COMM_EXT:
-		return m.Update.ExtCommunity().Len() > 0
-	case ATTR_COMM_LARGE:
-		return m.Update.LargeCommunity().Len() > 0
-	case ATTR_OTC:
-		_, ok := m.Update.Otc()
-		return ok
-	case ATTR_DIR:
-		return m.Dir != 0
-	case ATTR_SEQ:
-		return m.Seq != 0
-	case ATTR_TIME:
-		return !m.Time.IsZero()
-	case ATTR_JSON, ATTR_JSONATTR:
-		upper := ev.getUpper()
-		if upper == nil {
-			return false
-		}
-		return bj.Get(upper, e.Idx.([]string)...) != nil
-	}
-	return false
+	return ev.cacheTime
 }
 
 // Run evaluates given Filter f against the current message.
@@ -160,20 +82,20 @@ func (ev *Eval) Run(f *Filter) (result bool) {
 	}
 
 	// check the expressions one by one
-	return ev.exprEval(f.First)
+	return ev.exprEval(f.First) == RES_TRUE
 }
 
-func (ev *Eval) exprEval(first *Expr) (result bool) {
+func (ev *Eval) exprEval(first *Expr) Res {
 	is_update := ev.Msg.Type == msg.UPDATE
-	prev_and := false
-	any_ok := false
+	var prev_and, any_true, any_false bool
 	for e := first; e != nil; e = e.Next {
-		var res, cache_ok bool
+		var res Res
 		switch {
 		case !is_update && !e.Types:
-			res = false // no need to run
-		case ev.cache != nil:
-			if res, cache_ok = ev.cache[e.String]; cache_ok {
+			res = RES_FALSE // no need to run
+		case len(ev.cache) > 0:
+			var ok bool
+			if res, ok = ev.cache[e.String]; ok {
 				break // use cached result in res
 			}
 			fallthrough
@@ -184,22 +106,29 @@ func (ev *Eval) exprEval(first *Expr) (result bool) {
 			}
 		}
 
-		// any success so far?
-		any_ok = any_ok || res
+		// any success/ failure so far?
+		any_true = any_true || res == RES_TRUE
+		any_false = any_false || res == RES_FALSE
 
 		// no need to keep checking?
 		is_and := prev_and || e.And // left or right is AND?
-		if res {
+		if res == RES_TRUE {
 			if !is_and {
-				return true // one True in OR chain is enough to succeed
+				return RES_TRUE // one True in OR chain is enough to succeed
 			}
-		} else {
+		} else { // = RES_FALSE or RES_ABSENT
 			if is_and {
-				return false // one False in AND chain is enough to fail
+				return RES_FALSE // one False in AND chain is enough to fail
 			}
 		}
 		prev_and = e.And
 	}
 
-	return any_ok
+	if any_true {
+		return RES_TRUE // at least one RES_TRUE
+	} else if any_false {
+		return RES_FALSE // at least one RES_FALSE
+	} else {
+		return RES_ABSENT // all were RES_ABSENT
+	}
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -26,9 +26,10 @@ type Expr struct {
 	String string  // raw expression string
 	Types  bool    // allow message types other than UPDATE?
 
-	Not  bool  // negate the final result of this expression?
-	And  bool  // apply logical AND with the next expression? (if false, apply OR)
-	Next *Expr // next expression (nil means last)
+	Not   bool // negate the final result of this expression?
+	OpNot bool // operator-level negation (!=, !~): negate match only if attribute exists
+	And   bool // apply logical AND with the next expression? (if false, apply OR)
+	Next  *Expr // next expression (nil means last)
 
 	Attr Attr // attribute
 	Idx  any  // index inside the attribute (eg. int(0) if aspath[0])
@@ -58,6 +59,13 @@ const (
 	ATTR_COMM                   // COMMUNITY attribute
 	ATTR_COMM_EXT               // EXTENDED_COMMUNITY attribute
 	ATTR_COMM_LARGE             // LARGE_COMMUNITY attribute
+	ATTR_ASPATH_HOPS            // AS_PATH unique hop count (ignoring prepending)
+	ATTR_OTC                    // OTC attribute (Only To Customer, RFC 9234)
+	ATTR_DIR                    // message direction (L/R)
+	ATTR_SEQ                    // message sequence number
+	ATTR_TIME                   // message timestamp
+	ATTR_JSON                   // generic JSON path extractor
+	ATTR_JSONATTR               // attribute-specific JSON extractor
 )
 
 const (
@@ -69,6 +77,23 @@ const (
 	OP_GE             // >=
 	OP_LIKE           // ~ (match)
 )
+
+// cmpOp evaluates a three-way comparison result against an operator.
+func cmpOp(cmp int, op Op) bool {
+	switch op {
+	case OP_EQ:
+		return cmp == 0
+	case OP_LT:
+		return cmp < 0
+	case OP_LE:
+		return cmp <= 0
+	case OP_GT:
+		return cmp > 0
+	case OP_GE:
+		return cmp >= 0
+	}
+	return false
+}
 
 func NewFilter(filter string) (*Filter, error) {
 	f := &Filter{
@@ -297,7 +322,7 @@ func (e *Expr) parseOp(op string) bool {
 		e.Op = OP_EQ
 	case "!=", "=!":
 		e.Op = OP_EQ
-		e.Not = !e.Not
+		e.OpNot = true
 	case "<":
 		e.Op = OP_LT
 	case "<=":
@@ -310,7 +335,7 @@ func (e *Expr) parseOp(op string) bool {
 		e.Op = OP_LIKE
 	case "!~", "~!":
 		e.Op = OP_LIKE
-		e.Not = !e.Not
+		e.OpNot = true
 	default:
 		return false // invalid operator
 	}
@@ -404,6 +429,8 @@ func (e *Expr) parseAttr(attr string) bool {
 		e.Idx = 0
 	case "aspath_len", "as_path_len":
 		e.Attr = ATTR_ASPATH_LEN
+	case "aspath_hops", "as_path_hops":
+		e.Attr = ATTR_ASPATH_HOPS
 
 	case "nexthop", "nh":
 		e.Attr = ATTR_NEXTHOP
@@ -421,6 +448,20 @@ func (e *Expr) parseAttr(attr string) bool {
 		e.Attr = ATTR_COMM_EXT
 	case "com_large", "large_community", "large_com":
 		e.Attr = ATTR_COMM_LARGE
+
+	case "otc", "only_to_customer":
+		e.Attr = ATTR_OTC
+
+	case "dir", "direction":
+		e.Attr = ATTR_DIR
+	case "seq", "sequence":
+		e.Attr = ATTR_SEQ
+	case "time", "timestamp":
+		e.Attr = ATTR_TIME
+	case "json":
+		e.Attr = ATTR_JSON
+	case "attr":
+		e.Attr = ATTR_JSONATTR
 
 	default:
 		return false
@@ -447,6 +488,8 @@ func (e *Expr) parseCheck() error {
 		return e.aspathParse()
 	case ATTR_ASPATH_LEN:
 		return e.aspathLenParse()
+	case ATTR_ASPATH_HOPS:
+		return e.aspathLenParse() // same validation as aspath_len
 	case ATTR_ORIGIN:
 		return e.originParse()
 	case ATTR_MED:
@@ -455,44 +498,78 @@ func (e *Expr) parseCheck() error {
 		return e.u32Parse()
 	case ATTR_COMM, ATTR_COMM_EXT, ATTR_COMM_LARGE:
 		return e.communityParse()
+	case ATTR_OTC:
+		return e.u32Parse()
+	case ATTR_DIR:
+		return e.dirParse()
+	case ATTR_SEQ:
+		return e.seqParse()
+	case ATTR_TIME:
+		return e.timeParse()
+	case ATTR_JSON, ATTR_JSONATTR:
+		return e.jsonParse()
 	default:
 		return fmt.Errorf("unsupported attribute")
 	}
 }
 
 func (e *Expr) eval(ev *Eval) (res bool) {
-	switch e.Attr {
-	case ATTR_EXPR: // sub-expression
-		res = ev.exprEval(e.Val.(*Expr))
-	case ATTR_TAG:
-		res = e.tagEval(ev)
-	case ATTR_TYPE:
-		res = e.typeEval(ev)
-	case ATTR_AF:
-		res = e.afEval(ev)
-	case ATTR_REACH, ATTR_UNREACH, ATTR_PREFIX:
-		res = e.prefixEval(ev)
-	case ATTR_NEXTHOP:
-		res = e.nexthopEval(ev)
-	case ATTR_ASPATH:
-		res = e.aspathEval(ev)
-	case ATTR_ASPATH_LEN:
-		res = e.aspathLenEval(ev)
-	case ATTR_ORIGIN:
-		res = e.originEval(ev)
-	case ATTR_MED:
-		res = e.medEval(ev)
-	case ATTR_LOCALPREF:
-		res = e.localprefEval(ev)
-	case ATTR_COMM, ATTR_COMM_EXT, ATTR_COMM_LARGE:
-		res = e.communityEval(ev)
-	default:
-		panic("not implemented")
+	res = e.evalAttr(ev)
+
+	// operator negation (!=, !~): negate match only if attribute exists
+	if e.OpNot {
+		if res {
+			res = false // matched → negated to false
+		} else {
+			res = ev.attrExists(e) // didn't match → true only if attr exists
+		}
 	}
 
 	if e.Not {
 		return !res
-	} else {
-		return res
+	}
+	return res
+}
+
+func (e *Expr) evalAttr(ev *Eval) bool {
+	switch e.Attr {
+	case ATTR_EXPR: // sub-expression
+		return ev.exprEval(e.Val.(*Expr))
+	case ATTR_TAG:
+		return e.tagEval(ev)
+	case ATTR_TYPE:
+		return e.typeEval(ev)
+	case ATTR_AF:
+		return e.afEval(ev)
+	case ATTR_REACH, ATTR_UNREACH, ATTR_PREFIX:
+		return e.prefixEval(ev)
+	case ATTR_NEXTHOP:
+		return e.nexthopEval(ev)
+	case ATTR_ASPATH:
+		return e.aspathEval(ev)
+	case ATTR_ASPATH_LEN:
+		return e.aspathLenEval(ev)
+	case ATTR_ASPATH_HOPS:
+		return e.aspathHopsEval(ev)
+	case ATTR_ORIGIN:
+		return e.originEval(ev)
+	case ATTR_MED:
+		return e.medEval(ev)
+	case ATTR_LOCALPREF:
+		return e.localprefEval(ev)
+	case ATTR_COMM, ATTR_COMM_EXT, ATTR_COMM_LARGE:
+		return e.communityEval(ev)
+	case ATTR_OTC:
+		return e.otcEval(ev)
+	case ATTR_DIR:
+		return e.dirEval(ev)
+	case ATTR_SEQ:
+		return e.seqEval(ev)
+	case ATTR_TIME:
+		return e.timeEval(ev)
+	case ATTR_JSON, ATTR_JSONATTR:
+		return e.jsonEval(ev)
+	default:
+		panic("not implemented")
 	}
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -26,10 +26,9 @@ type Expr struct {
 	String string  // raw expression string
 	Types  bool    // allow message types other than UPDATE?
 
-	Not   bool // negate the final result of this expression?
-	OpNot bool // operator-level negation (!=, !~): negate match only if attribute exists
-	And   bool // apply logical AND with the next expression? (if false, apply OR)
-	Next  *Expr // next expression (nil means last)
+	Not  bool  // negate the final result of this expression?
+	And  bool  // apply logical AND with the next expression? (if false, apply OR)
+	Next *Expr // next expression (nil means last)
 
 	Attr Attr // attribute
 	Idx  any  // index inside the attribute (eg. int(0) if aspath[0])
@@ -40,59 +39,80 @@ type Expr struct {
 type (
 	Attr = int
 	Op   = int
+	Res  = int8
 )
 
 const (
-	ATTR_EXPR       Attr = iota // sub-expression in value (nested)
-	ATTR_TAG                    // message tag (from pipe context)
-	ATTR_TYPE                   // BGP message type
-	ATTR_AF                     // address family / subsequent address family
-	ATTR_REACH                  // reachable prefixes
-	ATTR_UNREACH                // unreachable prefixes
-	ATTR_PREFIX                 // prefix, either reachable or unreachable
-	ATTR_ASPATH                 // AS_PATH attribute
-	ATTR_ASPATH_LEN             // AS_PATH length
-	ATTR_NEXTHOP                // NEXT_HOP attribute
-	ATTR_ORIGIN                 // ORIGIN attribute (IGP/EGP/INCOMPLETE)
-	ATTR_MED                    // MULTI_EXIT_DISC attribute
-	ATTR_LOCALPREF              // LOCAL_PREF attribute
-	ATTR_COMM                   // COMMUNITY attribute
-	ATTR_COMM_EXT               // EXTENDED_COMMUNITY attribute
-	ATTR_COMM_LARGE             // LARGE_COMMUNITY attribute
-	ATTR_ASPATH_HOPS            // AS_PATH unique hop count (ignoring prepending)
-	ATTR_OTC                    // OTC attribute (Only To Customer, RFC 9234)
-	ATTR_DIR                    // message direction (L/R)
-	ATTR_SEQ                    // message sequence number
-	ATTR_TIME                   // message timestamp
-	ATTR_JSON                   // generic JSON path extractor
-	ATTR_JSONATTR               // attribute-specific JSON extractor
+	RES_FALSE  Res = -1 // evaluated to false
+	RES_ABSENT Res = 0  // referenced attribute not found
+	RES_TRUE   Res = 1  // evaluated to true
 )
 
 const (
-	OP_TRUE Op = iota // is true? (no value)
-	OP_EQ             // ==
-	OP_LT             // <
-	OP_LE             // <=
-	OP_GT             // >
-	OP_GE             // >=
-	OP_LIKE           // ~ (match)
+	ATTR_EXPR        Attr = iota // sub-expression in value (nested)
+	ATTR_TAG                     // message tag (from pipe context)
+	ATTR_TYPE                    // BGP message type
+	ATTR_AF                      // address family / subsequent address family
+	ATTR_REACH                   // reachable prefixes
+	ATTR_UNREACH                 // unreachable prefixes
+	ATTR_PREFIX                  // prefix, either reachable or unreachable
+	ATTR_ASPATH                  // AS_PATH attribute
+	ATTR_ASPATH_LEN              // AS_PATH length
+	ATTR_ASPATH_HOPS             // AS_PATH unique hop count (ignore prepending)
+	ATTR_NEXTHOP                 // NEXT_HOP attribute
+	ATTR_ORIGIN                  // ORIGIN attribute (IGP/EGP/INCOMPLETE)
+	ATTR_MED                     // MULTI_EXIT_DISC attribute
+	ATTR_LOCALPREF               // LOCAL_PREF attribute
+	ATTR_COMM                    // COMMUNITY attribute
+	ATTR_COMM_EXT                // EXTENDED_COMMUNITY attribute
+	ATTR_COMM_LARGE              // LARGE_COMMUNITY attribute
+	ATTR_OTC                     // OTC attribute (Only To Customer, RFC 9234)
+	ATTR_DIR                     // message direction (L/R)
+	ATTR_SEQ                     // message sequence number
+	ATTR_TIME                    // message timestamp
+	ATTR_JSON                    // generic JSON path extractor
+	ATTR_JATTR                   // attribute-specific JSON extractor
 )
 
-// cmpOp evaluates a three-way comparison result against an operator.
-func cmpOp(cmp int, op Op) bool {
+const (
+	OP_PRESENT Op = iota // attribute exists? (no value)
+	OP_EQ                // ==
+	OP_LT                // <
+	OP_LE                // <=
+	OP_GT                // >
+	OP_GE                // >=
+	OP_LIKE              // ~ (match)
+)
+
+// resBool converts a bool to Res.
+func resBool(v bool) Res {
+	if v {
+		return RES_TRUE
+	} else {
+		return RES_FALSE
+	}
+}
+
+// resCmp evaluates a three-way comparison result against an operator.
+func resCmp(op Op, cmp int) Res {
+	var ok bool
 	switch op {
 	case OP_EQ:
-		return cmp == 0
+		ok = cmp == 0
 	case OP_LT:
-		return cmp < 0
+		ok = cmp < 0
 	case OP_LE:
-		return cmp <= 0
+		ok = cmp <= 0
 	case OP_GT:
-		return cmp > 0
+		ok = cmp > 0
 	case OP_GE:
-		return cmp >= 0
+		ok = cmp >= 0
 	}
-	return false
+	if ok {
+		return RES_TRUE
+	} else {
+		return RES_FALSE
+	}
 }
 
 func NewFilter(filter string) (*Filter, error) {
@@ -322,7 +342,7 @@ func (e *Expr) parseOp(op string) bool {
 		e.Op = OP_EQ
 	case "!=", "=!":
 		e.Op = OP_EQ
-		e.OpNot = true
+		e.Not = !e.Not
 	case "<":
 		e.Op = OP_LT
 	case "<=":
@@ -335,7 +355,7 @@ func (e *Expr) parseOp(op string) bool {
 		e.Op = OP_LIKE
 	case "!~", "~!":
 		e.Op = OP_LIKE
-		e.OpNot = true
+		e.Not = !e.Not
 	default:
 		return false // invalid operator
 	}
@@ -461,7 +481,7 @@ func (e *Expr) parseAttr(attr string) bool {
 	case "json":
 		e.Attr = ATTR_JSON
 	case "attr":
-		e.Attr = ATTR_JSONATTR
+		e.Attr = ATTR_JATTR
 
 	default:
 		return false
@@ -506,70 +526,75 @@ func (e *Expr) parseCheck() error {
 		return e.seqParse()
 	case ATTR_TIME:
 		return e.timeParse()
-	case ATTR_JSON, ATTR_JSONATTR:
+	case ATTR_JSON, ATTR_JATTR:
 		return e.jsonParse()
 	default:
 		return fmt.Errorf("unsupported attribute")
 	}
 }
 
-func (e *Expr) eval(ev *Eval) (res bool) {
-	res = e.evalAttr(ev)
-
-	// operator negation (!=, !~): negate match only if attribute exists
-	if e.OpNot {
-		if res {
-			res = false // matched → negated to false
-		} else {
-			res = ev.attrExists(e) // didn't match → true only if attr exists
-		}
-	}
-
-	if e.Not {
-		return !res
-	}
-	return res
-}
-
-func (e *Expr) evalAttr(ev *Eval) bool {
+func (e *Expr) eval(ev *Eval) (res Res) {
 	switch e.Attr {
 	case ATTR_EXPR: // sub-expression
-		return ev.exprEval(e.Val.(*Expr))
+		res = ev.exprEval(e.Val.(*Expr))
 	case ATTR_TAG:
-		return e.tagEval(ev)
+		res = e.tagEval(ev)
 	case ATTR_TYPE:
-		return e.typeEval(ev)
+		res = e.typeEval(ev)
 	case ATTR_AF:
-		return e.afEval(ev)
+		res = e.afEval(ev)
 	case ATTR_REACH, ATTR_UNREACH, ATTR_PREFIX:
-		return e.prefixEval(ev)
+		res = e.prefixEval(ev)
 	case ATTR_NEXTHOP:
-		return e.nexthopEval(ev)
+		res = e.nexthopEval(ev)
 	case ATTR_ASPATH:
-		return e.aspathEval(ev)
+		res = e.aspathEval(ev)
 	case ATTR_ASPATH_LEN:
-		return e.aspathLenEval(ev)
+		res = e.aspathLenEval(ev)
 	case ATTR_ASPATH_HOPS:
-		return e.aspathHopsEval(ev)
+		res = e.aspathHopsEval(ev)
 	case ATTR_ORIGIN:
-		return e.originEval(ev)
+		res = e.originEval(ev)
 	case ATTR_MED:
-		return e.medEval(ev)
+		res = e.medEval(ev)
 	case ATTR_LOCALPREF:
-		return e.localprefEval(ev)
+		res = e.localprefEval(ev)
 	case ATTR_COMM, ATTR_COMM_EXT, ATTR_COMM_LARGE:
-		return e.communityEval(ev)
+		res = e.communityEval(ev)
 	case ATTR_OTC:
-		return e.otcEval(ev)
+		res = e.otcEval(ev)
 	case ATTR_DIR:
-		return e.dirEval(ev)
+		res = e.dirEval(ev)
 	case ATTR_SEQ:
-		return e.seqEval(ev)
+		res = e.seqEval(ev)
 	case ATTR_TIME:
-		return e.timeEval(ev)
-	case ATTR_JSON, ATTR_JSONATTR:
-		return e.jsonEval(ev)
+		res = e.timeEval(ev)
+	case ATTR_JSON, ATTR_JATTR:
+		res = e.jsonEval(ev)
 	default:
 		panic("not implemented")
 	}
+
+	// transform the raw result?
+	if e.Not {
+		switch res {
+		case RES_TRUE:
+			res = RES_FALSE
+		case RES_FALSE:
+			res = RES_TRUE
+		case RES_ABSENT:
+			if e.Op == OP_PRESENT {
+				res = RES_TRUE // treat as TRUE if !OP_PRESENT
+			}
+		}
+	} else {
+		switch res {
+		case RES_ABSENT:
+			if e.Op == OP_PRESENT {
+				res = RES_FALSE // treat as FALSE if OP_PRESENT
+			}
+		}
+	}
+
+	return res
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -3,8 +3,10 @@ package filter
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/bgpfix/bgpfix/attrs"
+	"github.com/bgpfix/bgpfix/dir"
 	"github.com/bgpfix/bgpfix/msg"
 	"github.com/bgpfix/bgpfix/nlri"
 	"github.com/stretchr/testify/assert"
@@ -66,6 +68,12 @@ func setLocalPref(m *msg.Msg, lp uint32) {
 	a.Val = lp
 }
 
+// setOtc sets the OTC attribute
+func setOtc(m *msg.Msg, otc uint32) {
+	a := m.Update.Attrs.Use(attrs.ATTR_OTC).(*attrs.U32)
+	a.Val = otc
+}
+
 // setCommunity sets standard communities from "ASN:VALUE" pairs
 func setCommunity(m *msg.Msg, pairs ...string) {
 	c := m.Update.Attrs.Use(attrs.ATTR_COMMUNITY).(*attrs.Community)
@@ -125,12 +133,20 @@ func TestParseValid(t *testing.T) {
 		"aspath ~ \"65001\"",
 		"as_peer >= 100",
 		"as_upstream == 3356",
+		"aspath[*] > 100",
+		"aspath[*] == 65001",
 
 		// aspath_len
 		"aspath_len > 5",
 		"aspath_len == 0",
 		"as_path_len <= 10",
 		"aspath_len",
+
+		// aspath_hops
+		"aspath_hops > 3",
+		"aspath_hops == 2",
+		"as_path_hops <= 10",
+		"aspath_hops",
 
 		// nexthop
 		"nexthop",
@@ -156,6 +172,12 @@ func TestParseValid(t *testing.T) {
 		"localpref == 100",
 		"local_pref > 50",
 		"local_pref <= 200",
+
+		// otc
+		"otc",
+		"otc == 65001",
+		"otc > 0",
+		"only_to_customer <= 64512",
 
 		// community
 		`community`,
@@ -195,8 +217,12 @@ func TestParseInvalid(t *testing.T) {
 		{"med == hello", "med non-integer"},
 		{"med ~ 100", "med like"},
 		{"local_pref ~ 100", "localpref like"},
+		{"otc ~ 100", "otc like"},
+		{"otc == hello", "otc non-integer"},
 		{"aspath_len ~ 5", "aspath_len like"},
 		{"aspath_len == -1", "aspath_len negative"},
+		{"aspath_hops ~ 5", "aspath_hops like"},
+		{"aspath_hops == -1", "aspath_hops negative"},
 		{"prefix ==", "missing value"},
 		{"prefix == not_a_prefix", "bad prefix value"},
 		{"(prefix == 1.2.3.4/32", "unmatched open paren"},
@@ -304,6 +330,12 @@ func TestEvalAsPath(t *testing.T) {
 	assert.True(t, evalFilter(t, m, `aspath ~ "3356,15169$"`))
 	assert.False(t, evalFilter(t, m, `aspath ~ "^15169"`))
 
+	// aspath[*] - any hop match (same as no index)
+	assert.True(t, evalFilter(t, m, "aspath[*] == 3356"))    // 3356 is in the path
+	assert.True(t, evalFilter(t, m, "aspath[*] > 10000"))    // 65001 and 15169 are > 10000
+	assert.False(t, evalFilter(t, m, "aspath[*] == 9999"))   // 9999 not in path
+	assert.True(t, evalFilter(t, m, "aspath[*] >= 3356"))    // 3356 matches
+
 	// negation
 	assert.True(t, evalFilter(t, m, "as_origin != 9999"))
 	assert.False(t, evalFilter(t, m, "as_origin != 15169"))
@@ -335,6 +367,43 @@ func TestEvalAspathLen(t *testing.T) {
 	assert.False(t, evalFilter(t, m2, "aspath_len == 0"))
 }
 
+func TestEvalAspathHops(t *testing.T) {
+	// path with prepending: 65001 3356 3356 3356 15169
+	// aspath_len = 5, aspath_hops = 3 (unique consecutive)
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	setAsPath(m, 65001, 3356, 3356, 3356, 15169)
+
+	assert.True(t, evalFilter(t, m, "aspath_hops"))
+	assert.True(t, evalFilter(t, m, "aspath_hops == 3"))
+	assert.False(t, evalFilter(t, m, "aspath_hops == 5"))
+	assert.True(t, evalFilter(t, m, "aspath_hops > 2"))
+	assert.True(t, evalFilter(t, m, "aspath_hops >= 3"))
+	assert.True(t, evalFilter(t, m, "aspath_hops < 4"))
+	assert.True(t, evalFilter(t, m, "aspath_hops <= 3"))
+	assert.False(t, evalFilter(t, m, "aspath_hops > 3"))
+
+	// no prepending: 65001 3356 15169
+	m2 := newUpdate()
+	addReach(m2, "10.0.0.0/24")
+	setAsPath(m2, 65001, 3356, 15169)
+	assert.True(t, evalFilter(t, m2, "aspath_hops == 3"))
+	assert.True(t, evalFilter(t, m2, "aspath_len == 3"))
+
+	// all prepending: 65001 65001 65001
+	m3 := newUpdate()
+	addReach(m3, "10.0.0.0/24")
+	setAsPath(m3, 65001, 65001, 65001)
+	assert.True(t, evalFilter(t, m3, "aspath_hops == 1"))
+	assert.True(t, evalFilter(t, m3, "aspath_len == 3"))
+
+	// no aspath
+	m4 := newUpdate()
+	addReach(m4, "10.0.0.0/24")
+	assert.False(t, evalFilter(t, m4, "aspath_hops"))
+	assert.False(t, evalFilter(t, m4, "aspath_hops == 0"))
+}
+
 func TestEvalOrigin(t *testing.T) {
 	m := newUpdate()
 	addReach(m, "10.0.0.0/24")
@@ -353,6 +422,11 @@ func TestEvalOrigin(t *testing.T) {
 	addReach(m2, "10.0.0.0/24")
 	assert.False(t, evalFilter(t, m2, "origin"))
 	assert.False(t, evalFilter(t, m2, "origin == igp"))
+
+	// != with absent attribute: should be false (not true)
+	assert.False(t, evalFilter(t, m2, "origin != igp"))
+	// contrast with !origin == igp which IS true (negation of "has igp origin")
+	assert.True(t, evalFilter(t, m2, "!origin == igp"))
 }
 
 func TestEvalMed(t *testing.T) {
@@ -373,6 +447,7 @@ func TestEvalMed(t *testing.T) {
 	m2 := newUpdate()
 	addReach(m2, "10.0.0.0/24")
 	assert.False(t, evalFilter(t, m2, "med"))
+	assert.False(t, evalFilter(t, m2, "med != 100")) // absent → false, not true
 }
 
 func TestEvalLocalPref(t *testing.T) {
@@ -392,6 +467,28 @@ func TestEvalLocalPref(t *testing.T) {
 	m2 := newUpdate()
 	addReach(m2, "10.0.0.0/24")
 	assert.False(t, evalFilter(t, m2, "local_pref"))
+}
+
+func TestEvalOtc(t *testing.T) {
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	setOtc(m, 65001)
+
+	assert.True(t, evalFilter(t, m, "otc"))
+	assert.True(t, evalFilter(t, m, "otc == 65001"))
+	assert.False(t, evalFilter(t, m, "otc == 65002"))
+	assert.True(t, evalFilter(t, m, "otc > 65000"))
+	assert.True(t, evalFilter(t, m, "otc >= 65001"))
+	assert.True(t, evalFilter(t, m, "otc < 65002"))
+	assert.True(t, evalFilter(t, m, "otc <= 65001"))
+	assert.False(t, evalFilter(t, m, "otc > 65001"))
+	assert.True(t, evalFilter(t, m, "only_to_customer == 65001"))
+
+	// no otc
+	m2 := newUpdate()
+	addReach(m2, "10.0.0.0/24")
+	assert.False(t, evalFilter(t, m2, "otc"))
+	assert.False(t, evalFilter(t, m2, "otc == 65001"))
 }
 
 func TestEvalNexthop(t *testing.T) {
@@ -431,6 +528,8 @@ func TestEvalCommunity(t *testing.T) {
 	m2 := newUpdate()
 	addReach(m2, "10.0.0.0/24")
 	assert.False(t, evalFilter(t, m2, "community"))
+	assert.False(t, evalFilter(t, m2, `community != "3356:100"`)) // absent → false
+	assert.False(t, evalFilter(t, m2, `com !~ "3356:"`))          // absent → false
 }
 
 func TestEvalTag(t *testing.T) {
@@ -476,6 +575,7 @@ func TestEvalNonUpdate(t *testing.T) {
 	assert.False(t, evalFilter(t, ka, "aspath"))
 	assert.False(t, evalFilter(t, ka, "origin == igp"))
 	assert.False(t, evalFilter(t, ka, "med > 0"))
+	assert.False(t, evalFilter(t, ka, "otc"))
 
 	// but type filters work
 	assert.True(t, evalFilter(t, ka, "keepalive"))
@@ -563,4 +663,273 @@ func TestEvalCache(t *testing.T) {
 	m.Edit()
 	setOrigin(m, 1) // EGP
 	assert.False(t, ev.Run(f))
+}
+
+// --- json/attr/time parse tests ---
+
+func TestParseValidJsonAttrTime(t *testing.T) {
+	valid := []string{
+		// dir
+		`dir`,
+		`dir == L`,
+		`dir == R`,
+		`dir != L`,
+
+		// seq
+		`seq`,
+		`seq == 1`,
+		`seq > 0`,
+		`seq <= 100`,
+
+		// json
+		`json[attrs.ORIGIN.value]`,
+		`json[reach]`,
+		`json[attrs.MED.value] > 100`,
+		`json[attrs.ORIGIN.value] == IGP`,
+		`json[attrs.ORIGIN.value] ~ "^I"`,
+
+		// attr
+		`attr[ORIGIN]`,
+		`attr[MP_REACH.af]`,
+		`attr[MED] > 100`,
+		`attr[COMMUNITY] ~ "3356:"`,
+		`attr[ORIGIN] == IGP`,
+
+		// time
+		`time`,
+		`time == "2023-03-01T00:00:00.000"`,
+		`time ~ "^2023"`,
+		`time > "2023-01-01"`,
+		`time >= "2023-01-01T00:00:00.000"`,
+		`time < "2024-01-01"`,
+		`timestamp`,
+	}
+
+	for _, tc := range valid {
+		t.Run(tc, func(t *testing.T) {
+			_, err := NewFilter(tc)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestParseInvalidJsonAttrTime(t *testing.T) {
+	invalid := []struct {
+		filter string
+		name   string
+	}{
+		{"json", "json no index"},
+		{"attr", "attr no index"},
+		{"attr[BOGUS]", "unknown attr"},
+		{"json[x] > hello", "numeric op non-numeric value"},
+		{"time[x]", "time with index"},
+		{"dir > L", "dir bad op"},
+		{"dir == X", "dir bad value"},
+		{"dir[0]", "dir with index"},
+		{"seq ~ 1", "seq like"},
+		{"seq == hello", "seq non-integer"},
+		{"seq[0]", "seq with index"},
+	}
+
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewFilter(tc.filter)
+			assert.Error(t, err, "expected error for: %s", tc.filter)
+		})
+	}
+}
+
+// --- json eval tests ---
+
+func TestEvalJson(t *testing.T) {
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	setOrigin(m, 0) // IGP
+	setMed(m, 500)
+	setCommunity(m, "3356:100", "174:200")
+
+	// existence
+	assert.True(t, evalFilter(t, m, `json[attrs.ORIGIN.value]`))
+	assert.True(t, evalFilter(t, m, `json[reach]`))
+	assert.False(t, evalFilter(t, m, `json[unreach]`))
+	assert.False(t, evalFilter(t, m, `json[attrs.LOCALPREF.value]`))
+
+	// string eq
+	assert.True(t, evalFilter(t, m, `json[attrs.ORIGIN.value] == IGP`))
+	assert.False(t, evalFilter(t, m, `json[attrs.ORIGIN.value] == EGP`))
+
+	// negation
+	assert.True(t, evalFilter(t, m, `json[attrs.ORIGIN.value] != EGP`))
+	assert.False(t, evalFilter(t, m, `json[attrs.ORIGIN.value] != IGP`))
+
+	// regex
+	assert.True(t, evalFilter(t, m, `json[attrs.ORIGIN.value] ~ "^I"`))
+	assert.False(t, evalFilter(t, m, `json[attrs.ORIGIN.value] ~ "^E"`))
+
+	// numeric comparison on MED value
+	assert.True(t, evalFilter(t, m, `json[attrs.MED.value] > 100`))
+	assert.True(t, evalFilter(t, m, `json[attrs.MED.value] == 500`))
+	assert.False(t, evalFilter(t, m, `json[attrs.MED.value] > 500`))
+	assert.True(t, evalFilter(t, m, `json[attrs.MED.value] >= 500`))
+	assert.True(t, evalFilter(t, m, `json[attrs.MED.value] < 1000`))
+
+	// regex on community array JSON
+	assert.True(t, evalFilter(t, m, `json[attrs.COMMUNITY.value] ~ "3356:"`))
+	assert.False(t, evalFilter(t, m, `json[attrs.COMMUNITY.value] ~ "9999:"`))
+
+	// != with absent path: should be false
+	assert.False(t, evalFilter(t, m, `json[attrs.LOCALPREF.value] != 100`))
+
+	// works on non-UPDATE for json (Types=true)
+	ka := msg.NewMsg()
+	ka.Switch(msg.KEEPALIVE)
+	assert.False(t, evalFilter(t, ka, `json[reach]`)) // KEEPALIVE has null upper layer
+}
+
+// --- attr eval tests ---
+
+func TestEvalAttr(t *testing.T) {
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	setOrigin(m, 0) // IGP
+	setMed(m, 500)
+	setCommunity(m, "3356:100", "174:200")
+
+	// attr[ORIGIN] → attrs.ORIGIN.value
+	assert.True(t, evalFilter(t, m, `attr[ORIGIN] == IGP`))
+	assert.False(t, evalFilter(t, m, `attr[ORIGIN] == EGP`))
+
+	// attr[MED] → attrs.MED.value
+	assert.True(t, evalFilter(t, m, `attr[MED] > 100`))
+	assert.True(t, evalFilter(t, m, `attr[MED] == 500`))
+	assert.False(t, evalFilter(t, m, `attr[MED] < 100`))
+
+	// attr[COMMUNITY] regex
+	assert.True(t, evalFilter(t, m, `attr[COMMUNITY] ~ "3356:"`))
+	assert.False(t, evalFilter(t, m, `attr[COMMUNITY] ~ "9999:"`))
+
+	// existence
+	assert.True(t, evalFilter(t, m, `attr[ORIGIN]`))
+	assert.False(t, evalFilter(t, m, `attr[LOCALPREF]`))
+
+	// case insensitive attr names
+	assert.True(t, evalFilter(t, m, `attr[origin] == IGP`))
+	assert.True(t, evalFilter(t, m, `attr[med] > 100`))
+}
+
+// --- time eval tests ---
+
+func TestEvalTime(t *testing.T) {
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	m.Time = time.Date(2023, 3, 1, 12, 30, 45, 0, time.UTC)
+
+	// existence
+	assert.True(t, evalFilter(t, m, `time`))
+
+	// exact match
+	assert.True(t, evalFilter(t, m, `time == "2023-03-01T12:30:45.000"`))
+	assert.False(t, evalFilter(t, m, `time == "2023-03-01T12:30:46.000"`))
+
+	// regex
+	assert.True(t, evalFilter(t, m, `time ~ "^2023-03"`))
+	assert.True(t, evalFilter(t, m, `time ~ "^2023"`))
+	assert.False(t, evalFilter(t, m, `time ~ "^2024"`))
+
+	// string comparison (lexicographic, correct for ISO 8601)
+	assert.True(t, evalFilter(t, m, `time > "2023-01-01"`))
+	assert.True(t, evalFilter(t, m, `time < "2024-01-01"`))
+	assert.True(t, evalFilter(t, m, `time >= "2023-03-01T12:30:45.000"`))
+	assert.True(t, evalFilter(t, m, `time <= "2023-03-01T12:30:45.000"`))
+	assert.False(t, evalFilter(t, m, `time > "2023-03-01T12:30:45.000"`))
+	assert.False(t, evalFilter(t, m, `time < "2023-03-01T12:30:45.000"`))
+
+	// zero time
+	m2 := newUpdate()
+	addReach(m2, "10.0.0.0/24")
+	assert.False(t, evalFilter(t, m2, `time`))
+	assert.False(t, evalFilter(t, m2, `time != "2023-01-01"`)) // absent → false
+
+	// works on non-UPDATE (Types=true)
+	ka := msg.NewMsg()
+	ka.Switch(msg.KEEPALIVE)
+	ka.Time = time.Date(2023, 6, 15, 0, 0, 0, 0, time.UTC)
+	assert.True(t, evalFilter(t, ka, `time`))
+	assert.True(t, evalFilter(t, ka, `time ~ "^2023-06"`))
+
+	// timestamp alias
+	assert.True(t, evalFilter(t, m, `timestamp`))
+}
+
+// --- dir eval tests ---
+
+func TestEvalDir(t *testing.T) {
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	m.Dir = dir.DIR_L
+
+	// existence
+	assert.True(t, evalFilter(t, m, `dir`))
+
+	// equality
+	assert.True(t, evalFilter(t, m, `dir == L`))
+	assert.False(t, evalFilter(t, m, `dir == R`))
+
+	// negation
+	assert.True(t, evalFilter(t, m, `dir != R`))
+	assert.False(t, evalFilter(t, m, `dir != L`))
+
+	// R direction
+	m.Dir = dir.DIR_R
+	assert.True(t, evalFilter(t, m, `dir == R`))
+	assert.False(t, evalFilter(t, m, `dir == L`))
+
+	// works on non-UPDATE (Types=true)
+	ka := msg.NewMsg()
+	ka.Switch(msg.KEEPALIVE)
+	ka.Dir = dir.DIR_R
+	assert.True(t, evalFilter(t, ka, `dir == R`))
+
+	// zero dir
+	m2 := newUpdate()
+	assert.False(t, evalFilter(t, m2, `dir`))
+	assert.False(t, evalFilter(t, m2, `dir != L`)) // absent → false
+}
+
+// --- seq eval tests ---
+
+func TestEvalSeq(t *testing.T) {
+	m := newUpdate()
+	addReach(m, "10.0.0.0/24")
+	m.Seq = 42
+
+	// existence
+	assert.True(t, evalFilter(t, m, `seq`))
+
+	// equality
+	assert.True(t, evalFilter(t, m, `seq == 42`))
+	assert.False(t, evalFilter(t, m, `seq == 100`))
+
+	// comparison
+	assert.True(t, evalFilter(t, m, `seq > 10`))
+	assert.True(t, evalFilter(t, m, `seq >= 42`))
+	assert.True(t, evalFilter(t, m, `seq < 100`))
+	assert.True(t, evalFilter(t, m, `seq <= 42`))
+	assert.False(t, evalFilter(t, m, `seq > 42`))
+	assert.False(t, evalFilter(t, m, `seq < 42`))
+
+	// negation
+	assert.True(t, evalFilter(t, m, `seq != 100`))
+	assert.False(t, evalFilter(t, m, `seq != 42`))
+
+	// zero seq
+	m2 := newUpdate()
+	assert.False(t, evalFilter(t, m2, `seq`))
+	assert.False(t, evalFilter(t, m2, `seq != 42`)) // absent → false
+
+	// works on non-UPDATE (Types=true)
+	ka := msg.NewMsg()
+	ka.Switch(msg.KEEPALIVE)
+	ka.Seq = 5
+	assert.True(t, evalFilter(t, ka, `seq == 5`))
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -425,8 +425,8 @@ func TestEvalOrigin(t *testing.T) {
 
 	// != with absent attribute: should be false (not true)
 	assert.False(t, evalFilter(t, m2, "origin != igp"))
-	// contrast with !origin == igp which IS true (negation of "has igp origin")
-	assert.True(t, evalFilter(t, m2, "!origin == igp"))
+	// !origin == igp also false for absent (both use Not toggle)
+	assert.False(t, evalFilter(t, m2, "!origin == igp"))
 }
 
 func TestEvalMed(t *testing.T) {
@@ -779,6 +779,10 @@ func TestEvalJson(t *testing.T) {
 
 	// != with absent path: should be false
 	assert.False(t, evalFilter(t, m, `json[attrs.LOCALPREF.value] != 100`))
+
+	// array index access (numeric path segments become [N])
+	assert.True(t, evalFilter(t, m, `json[reach.0] ~ "10\\."`))
+	assert.True(t, evalFilter(t, m, `attr[COMMUNITY.0] ~ "3356:"`))
 
 	// works on non-UPDATE for json (Types=true)
 	ka := msg.NewMsg()

--- a/filter/json.go
+++ b/filter/json.go
@@ -20,8 +20,8 @@ func (e *Expr) jsonParse() error {
 	// convert index to string, split on "."
 	path := strings.Split(fmt.Sprintf("%v", e.Idx), ".")
 
-	// for ATTR_JSONATTR: resolve attribute name and build path
-	if e.Attr == ATTR_JSONATTR {
+	// for ATTR_JATTR: resolve attribute name and build path
+	if e.Attr == ATTR_JATTR {
 		name := strings.ToUpper(path[0])
 
 		// try with ATTR_ prefix first, then without
@@ -44,9 +44,16 @@ func (e *Expr) jsonParse() error {
 		path = newPath
 	}
 
+	// convert numeric path segments to jsonparser array index format
+	for i, seg := range path {
+		if _, err := strconv.Atoi(seg); err == nil {
+			path[i] = "[" + seg + "]"
+		}
+	}
+
 	// validate value based on operator
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		// ok
 	case OP_EQ:
 		if _, ok := e.Val.(string); !ok {
@@ -82,30 +89,29 @@ func (e *Expr) jsonParse() error {
 	return nil
 }
 
-func (e *Expr) jsonEval(ev *Eval) bool {
-	upper := ev.getUpper()
-	if upper == nil {
-		return false
+func (e *Expr) jsonEval(ev *Eval) Res {
+	upper := ev.Msg.UpperJSON()
+	if len(upper) == 0 {
+		return RES_ABSENT // NB: should not happen
 	}
 
-	path := e.Idx.([]string)
-	val := bj.Get(upper, path...)
+	val := bj.Get(upper, e.Idx.([]string)...)
 	if val == nil {
-		return false
+		return RES_ABSENT
+	} else if e.Op == OP_PRESENT {
+		return RES_TRUE
 	}
 
 	switch e.Op {
-	case OP_TRUE:
-		return true
 	case OP_EQ:
-		return string(val) == e.Val.(string)
+		return resBool(string(val) == e.Val.(string))
 	case OP_LIKE:
-		return e.Val.(*regexp.Regexp).Match(val)
+		return resBool(e.Val.(*regexp.Regexp).Match(val))
 	default:
 		f, err := strconv.ParseFloat(string(val), 64)
 		if err != nil {
-			return false
+			return RES_FALSE
 		}
-		return cmpOp(cmp.Compare(f, e.Val.(float64)), e.Op)
+		return resCmp(e.Op, cmp.Compare(f, e.Val.(float64)))
 	}
 }

--- a/filter/json.go
+++ b/filter/json.go
@@ -1,0 +1,111 @@
+package filter
+
+import (
+	"cmp"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/bgpfix/bgpfix/attrs"
+	bj "github.com/bgpfix/bgpfix/json"
+)
+
+func (e *Expr) jsonParse() error {
+	// require index (path)
+	if e.Idx == nil {
+		return ErrIndex
+	}
+
+	// convert index to string, split on "."
+	path := strings.Split(fmt.Sprintf("%v", e.Idx), ".")
+
+	// for ATTR_JSONATTR: resolve attribute name and build path
+	if e.Attr == ATTR_JSONATTR {
+		name := strings.ToUpper(path[0])
+
+		// try with ATTR_ prefix first, then without
+		code, err := attrs.CodeString("ATTR_" + name)
+		if err != nil {
+			code, err = attrs.CodeString(name)
+		}
+		if err != nil {
+			return fmt.Errorf("unknown attribute: %s", path[0])
+		}
+
+		// use proper case name from CodeName
+		attrName := attrs.CodeName[code]
+
+		// build path: attrs -> NAME -> value -> remaining subpath
+		newPath := []string{"attrs", attrName, "value"}
+		if len(path) > 1 {
+			newPath = append(newPath, path[1:]...)
+		}
+		path = newPath
+	}
+
+	// validate value based on operator
+	switch e.Op {
+	case OP_TRUE:
+		// ok
+	case OP_EQ:
+		if _, ok := e.Val.(string); !ok {
+			e.Val = fmt.Sprintf("%v", e.Val)
+		}
+	case OP_LIKE:
+		re, err := regexp.Compile(e.Val.(string))
+		if err != nil {
+			return fmt.Errorf("invalid regex: %w", err)
+		}
+		e.Val = re
+	case OP_LT, OP_LE, OP_GT, OP_GE:
+		switch v := e.Val.(type) {
+		case int:
+			e.Val = float64(v)
+		case float64:
+			// already good
+		default:
+			return fmt.Errorf("numeric operator requires numeric value")
+		}
+	default:
+		return ErrOp
+	}
+
+	// store path
+	e.Idx = path
+
+	// json works on all message types
+	if e.Attr == ATTR_JSON {
+		e.Types = true
+	}
+
+	return nil
+}
+
+func (e *Expr) jsonEval(ev *Eval) bool {
+	upper := ev.getUpper()
+	if upper == nil {
+		return false
+	}
+
+	path := e.Idx.([]string)
+	val := bj.Get(upper, path...)
+	if val == nil {
+		return false
+	}
+
+	switch e.Op {
+	case OP_TRUE:
+		return true
+	case OP_EQ:
+		return string(val) == e.Val.(string)
+	case OP_LIKE:
+		return e.Val.(*regexp.Regexp).Match(val)
+	default:
+		f, err := strconv.ParseFloat(string(val), 64)
+		if err != nil {
+			return false
+		}
+		return cmpOp(cmp.Compare(f, e.Val.(float64)), e.Op)
+	}
+}

--- a/filter/nexthop.go
+++ b/filter/nexthop.go
@@ -13,7 +13,7 @@ func (e *Expr) nexthopParse() error {
 	}
 
 	// OP_TRUE is simple
-	if e.Op == OP_TRUE {
+	if e.Op == OP_PRESENT {
 		return nil
 	}
 
@@ -38,36 +38,32 @@ func (e *Expr) nexthopParse() error {
 	return nil
 }
 
-func (e *Expr) nexthopEval(ev *Eval) bool {
-	upd := &ev.Msg.Update
-
-	// get message nexthop
-	nh := upd.NextHop()
+func (e *Expr) nexthopEval(ev *Eval) Res {
+	nh := ev.Msg.Update.NextHop()
 	if !nh.IsValid() {
-		return false // no nexthop, or invalid value
-	} else if e.Op == OP_TRUE {
-		return true // any nexthop is OK
+		return RES_ABSENT
 	}
-
-	// check
+	if e.Op == OP_PRESENT {
+		return RES_TRUE
+	}
 	ref := e.Val.(nlri.Prefix)
 	ra := ref.Addr()
 	if ra.Is4() != nh.Is4() {
-		return false // different address families never match
+		return RES_FALSE // different address families never match
 	}
 	switch e.Op {
 	case OP_EQ:
-		return ra == nh
+		return resBool(ra == nh)
 	case OP_LT:
-		return nh.Less(ra)
+		return resBool(nh.Less(ra))
 	case OP_LE:
-		return nh == ra || nh.Less(ra)
+		return resBool(nh == ra || nh.Less(ra))
 	case OP_GT:
-		return ra.Less(nh)
+		return resBool(ra.Less(nh))
 	case OP_GE:
-		return nh == ra || ra.Less(nh)
+		return resBool(nh == ra || ra.Less(nh))
 	case OP_LIKE:
-		return ref.Bits() == 0 || ref.Contains(nh)
+		return resBool(ref.Bits() == 0 || ref.Contains(nh))
 	}
 
 	panic("unreachable") // should never happen

--- a/filter/origin.go
+++ b/filter/origin.go
@@ -11,7 +11,7 @@ func (e *Expr) originParse() error {
 	}
 
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		return nil
 	case OP_EQ:
 		// accept int or string
@@ -41,13 +41,13 @@ func (e *Expr) originParse() error {
 	return nil
 }
 
-func (e *Expr) originEval(ev *Eval) bool {
+func (e *Expr) originEval(ev *Eval) Res {
 	origin, ok := ev.Msg.Update.Origin()
 	if !ok {
-		return false
+		return RES_ABSENT
 	}
-	if e.Op == OP_TRUE {
-		return true
+	if e.Op == OP_PRESENT {
+		return RES_TRUE
 	}
-	return origin == e.Val.(byte)
+	return resBool(origin == e.Val.(byte))
 }

--- a/filter/prefix.go
+++ b/filter/prefix.go
@@ -12,8 +12,8 @@ func (e *Expr) prefixParse() error {
 		return ErrIndex
 	}
 
-	// only reach/unreach support OP_TRUE
-	if e.Op == OP_TRUE {
+	// only reach/unreach support OP_PRESENT
+	if e.Op == OP_PRESENT {
 		if e.Attr == ATTR_PREFIX {
 			return ErrOp
 		}
@@ -36,29 +36,33 @@ func (e *Expr) prefixParse() error {
 	return nil
 }
 
-func (e *Expr) prefixEval(ev *Eval) bool {
+func (e *Expr) prefixEval(ev *Eval) Res {
 	upd := &ev.Msg.Update
 
-	// collect prefixes
-	var prefixes []nlri.Prefix
+	// collect todo
+	var todo [2][]nlri.Prefix
 	switch e.Attr {
 	case ATTR_REACH:
-		prefixes = upd.AllReach()
+		todo[0] = upd.AllReach()
 	case ATTR_UNREACH:
-		prefixes = upd.AllUnreach()
+		todo[0] = upd.AllUnreach()
 	case ATTR_PREFIX:
-		prefixes = upd.AllReach() // start with reachable prefixes
+		todo[0] = upd.AllReach()
+		todo[1] = upd.AllUnreach()
 	}
 
-	// simple check? (only for reach/unreach)
-	if e.Op == OP_TRUE {
-		return len(prefixes) > 0
+	// no prefixes at all?
+	if len(todo[0])+len(todo[1]) == 0 {
+		return RES_ABSENT
+	}
+	if e.Op == OP_PRESENT {
+		return resBool(len(todo[0]) > 0) // only for reach/unreach
 	}
 
 	// check checks specific prefix value
 	ref := e.Val.(nlri.Prefix)
 	ra, rb := ref.Addr().Unmap(), ref.Bits()
-	check := func(pfx *nlri.Prefix) bool {
+	check := func(pfx nlri.Prefix) bool {
 		pa, pb := pfx.Addr().Unmap(), pfx.Bits()
 		if ra.Is4() != pa.Is4() {
 			return false // different address families never match
@@ -84,28 +88,21 @@ func (e *Expr) prefixEval(ev *Eval) bool {
 	// iterate over prefixes, compare vs. ref
 	all := e.Idx == "*" // must match all prefixes?
 	any_ok := false     // any OK so far?
-	for i := range 2 {
-		for p := range prefixes {
-			res := check(&prefixes[p])
+	for _, prefixes := range todo {
+		for _, pfx := range prefixes {
+			res := check(pfx)
 			any_ok = any_ok || res
 			if all {
 				if !res {
-					return false // all prefixes must match
+					return RES_FALSE // all prefixes must match
 				}
 			} else {
 				if res {
-					return true // any match is enough
+					return RES_TRUE // any match is enough
 				}
 			}
 		}
-
-		// keep searching in unreachable prefixes?
-		if i == 0 && e.Attr == ATTR_PREFIX {
-			prefixes = upd.AllUnreach()
-		} else {
-			break
-		}
 	}
 
-	return any_ok
+	return resBool(any_ok)
 }

--- a/filter/seq.go
+++ b/filter/seq.go
@@ -1,0 +1,35 @@
+package filter
+
+import (
+	"cmp"
+	"fmt"
+)
+
+func (e *Expr) seqParse() error {
+	if e.Idx != nil {
+		return ErrIndex
+	}
+
+	e.Types = true
+
+	if e.Op == OP_TRUE {
+		return nil
+	}
+	if e.Op == OP_LIKE {
+		return ErrOp
+	}
+
+	v, ok := e.Val.(int)
+	if !ok {
+		return fmt.Errorf("invalid value: %v (expected integer)", e.Val)
+	}
+	e.Val = int64(v)
+	return nil
+}
+
+func (e *Expr) seqEval(ev *Eval) bool {
+	if e.Op == OP_TRUE {
+		return ev.Msg.Seq != 0
+	}
+	return cmpOp(cmp.Compare(ev.Msg.Seq, e.Val.(int64)), e.Op)
+}

--- a/filter/seq.go
+++ b/filter/seq.go
@@ -12,10 +12,12 @@ func (e *Expr) seqParse() error {
 
 	e.Types = true
 
-	if e.Op == OP_TRUE {
-		return nil
-	}
-	if e.Op == OP_LIKE {
+	switch e.Op {
+	case OP_PRESENT:
+		return nil // ok
+	case OP_EQ, OP_LT, OP_LE, OP_GT, OP_GE:
+		break // value must be an integer
+	default:
 		return ErrOp
 	}
 
@@ -24,12 +26,16 @@ func (e *Expr) seqParse() error {
 		return fmt.Errorf("invalid value: %v (expected integer)", e.Val)
 	}
 	e.Val = int64(v)
+
 	return nil
 }
 
-func (e *Expr) seqEval(ev *Eval) bool {
-	if e.Op == OP_TRUE {
-		return ev.Msg.Seq != 0
+func (e *Expr) seqEval(ev *Eval) Res {
+	if ev.Msg.Seq == 0 {
+		return RES_ABSENT
+	} else if e.Op == OP_PRESENT {
+		return RES_TRUE
 	}
-	return cmpOp(cmp.Compare(ev.Msg.Seq, e.Val.(int64)), e.Op)
+
+	return resCmp(e.Op, cmp.Compare(ev.Msg.Seq, e.Val.(int64)))
 }

--- a/filter/tag.go
+++ b/filter/tag.go
@@ -8,7 +8,7 @@ import (
 func (e *Expr) tagParse() error {
 	// check operator (TRUE/EQ/LIKE), make value string or regexp
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		// non-empty tag or tags
 	case OP_EQ:
 		if _, ok := e.Val.(string); !ok {
@@ -35,17 +35,16 @@ func (e *Expr) tagParse() error {
 	return nil
 }
 
-func (e *Expr) tagEval(ev *Eval) bool {
-	// message has tags?
+func (e *Expr) tagEval(ev *Eval) Res {
 	tags := ev.PipeTags
 	if len(tags) == 0 {
-		return false
+		return RES_ABSENT
 	}
 
 	// check_val checks specific tag value
 	check_val := func(val string) bool {
 		switch e.Op {
-		case OP_TRUE:
+		case OP_PRESENT:
 			return val != ""
 		case OP_EQ:
 			return val == e.Val
@@ -58,13 +57,18 @@ func (e *Expr) tagEval(ev *Eval) bool {
 
 	// specific tag key?
 	if e.Idx != nil {
-		return check_val(tags[e.Idx.(string)])
-	} else { // look for any tag match
-		for _, val := range tags {
-			if check_val(val) {
-				return true
-			}
+		val := tags[e.Idx.(string)]
+		if val == "" {
+			return RES_ABSENT
 		}
-		return false
+		return resBool(check_val(val))
 	}
+
+	// look for any tag match
+	for _, val := range tags {
+		if check_val(val) {
+			return RES_TRUE
+		}
+	}
+	return RES_FALSE
 }

--- a/filter/time.go
+++ b/filter/time.go
@@ -1,0 +1,57 @@
+package filter
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func (e *Expr) timeParse() error {
+	// no index allowed
+	if e.Idx != nil {
+		return ErrIndex
+	}
+
+	switch e.Op {
+	case OP_TRUE:
+		// ok
+	case OP_EQ:
+		if _, ok := e.Val.(string); !ok {
+			e.Val = fmt.Sprintf("%v", e.Val)
+		}
+	case OP_LIKE:
+		re, err := regexp.Compile(e.Val.(string))
+		if err != nil {
+			return fmt.Errorf("invalid regex: %w", err)
+		}
+		e.Val = re
+	case OP_LT, OP_LE, OP_GT, OP_GE:
+		if _, ok := e.Val.(string); !ok {
+			e.Val = fmt.Sprintf("%v", e.Val)
+		}
+	default:
+		return ErrOp
+	}
+
+	e.Types = true
+	return nil
+}
+
+func (e *Expr) timeEval(ev *Eval) bool {
+	if ev.Msg.Time.IsZero() {
+		return false
+	}
+	if e.Op == OP_TRUE {
+		return true
+	}
+
+	ts := ev.getTime()
+	switch e.Op {
+	case OP_EQ:
+		return ts == e.Val.(string)
+	case OP_LIKE:
+		return e.Val.(*regexp.Regexp).MatchString(ts)
+	default:
+		return cmpOp(strings.Compare(ts, e.Val.(string)), e.Op)
+	}
+}

--- a/filter/time.go
+++ b/filter/time.go
@@ -3,7 +3,9 @@ package filter
 import (
 	"fmt"
 	"regexp"
-	"strings"
+	"time"
+
+	"github.com/itlightning/dateparse"
 )
 
 func (e *Expr) timeParse() error {
@@ -13,22 +15,20 @@ func (e *Expr) timeParse() error {
 	}
 
 	switch e.Op {
-	case OP_TRUE:
+	case OP_PRESENT:
 		// ok
-	case OP_EQ:
-		if _, ok := e.Val.(string); !ok {
-			e.Val = fmt.Sprintf("%v", e.Val)
-		}
 	case OP_LIKE:
 		re, err := regexp.Compile(e.Val.(string))
 		if err != nil {
 			return fmt.Errorf("invalid regex: %w", err)
 		}
 		e.Val = re
-	case OP_LT, OP_LE, OP_GT, OP_GE:
-		if _, ok := e.Val.(string); !ok {
-			e.Val = fmt.Sprintf("%v", e.Val)
+	case OP_EQ, OP_LT, OP_LE, OP_GT, OP_GE:
+		t, err := dateparse.ParseAny(fmt.Sprintf("%v", e.Val))
+		if err != nil {
+			return err
 		}
+		e.Val = t
 	default:
 		return ErrOp
 	}
@@ -37,21 +37,18 @@ func (e *Expr) timeParse() error {
 	return nil
 }
 
-func (e *Expr) timeEval(ev *Eval) bool {
+func (e *Expr) timeEval(ev *Eval) Res {
 	if ev.Msg.Time.IsZero() {
-		return false
-	}
-	if e.Op == OP_TRUE {
-		return true
+		return RES_ABSENT
+	} else if e.Op == OP_PRESENT {
+		return RES_TRUE
 	}
 
-	ts := ev.getTime()
 	switch e.Op {
-	case OP_EQ:
-		return ts == e.Val.(string)
 	case OP_LIKE:
-		return e.Val.(*regexp.Regexp).MatchString(ts)
+		ts := ev.getTime()
+		return resBool(e.Val.(*regexp.Regexp).MatchString(ts))
 	default:
-		return cmpOp(strings.Compare(ts, e.Val.(string)), e.Op)
+		return resCmp(e.Op, ev.Msg.Time.Compare(e.Val.(time.Time)))
 	}
 }

--- a/filter/type.go
+++ b/filter/type.go
@@ -36,6 +36,6 @@ func (e *Expr) typeParse() error {
 	return nil
 }
 
-func (e *Expr) typeEval(ev *Eval) bool {
-	return ev.Msg.Type == e.Val.(msg.Type)
+func (e *Expr) typeEval(ev *Eval) Res {
+	return resBool(ev.Msg.Type == e.Val.(msg.Type))
 }

--- a/filter/u32.go
+++ b/filter/u32.go
@@ -42,6 +42,14 @@ func (e *Expr) localprefEval(ev *Eval) bool {
 	return e.u32Eval(lp)
 }
 
+func (e *Expr) otcEval(ev *Eval) bool {
+	otc, ok := ev.Msg.Update.Otc()
+	if !ok {
+		return false
+	}
+	return e.u32Eval(otc)
+}
+
 func (e *Expr) u32Eval(val uint32) bool {
 	if e.Op == OP_TRUE {
 		return true

--- a/filter/u32.go
+++ b/filter/u32.go
@@ -8,7 +8,7 @@ func (e *Expr) u32Parse() error {
 		return ErrIndex
 	}
 
-	if e.Op == OP_TRUE {
+	if e.Op == OP_PRESENT {
 		return nil
 	}
 	if e.Op == OP_LIKE {
@@ -26,46 +26,46 @@ func (e *Expr) u32Parse() error {
 	return nil
 }
 
-func (e *Expr) medEval(ev *Eval) bool {
+func (e *Expr) medEval(ev *Eval) Res {
 	med, ok := ev.Msg.Update.Med()
 	if !ok {
-		return false
+		return RES_ABSENT
 	}
 	return e.u32Eval(med)
 }
 
-func (e *Expr) localprefEval(ev *Eval) bool {
+func (e *Expr) localprefEval(ev *Eval) Res {
 	lp, ok := ev.Msg.Update.LocalPref()
 	if !ok {
-		return false
+		return RES_ABSENT
 	}
 	return e.u32Eval(lp)
 }
 
-func (e *Expr) otcEval(ev *Eval) bool {
+func (e *Expr) otcEval(ev *Eval) Res {
 	otc, ok := ev.Msg.Update.Otc()
 	if !ok {
-		return false
+		return RES_ABSENT
 	}
 	return e.u32Eval(otc)
 }
 
-func (e *Expr) u32Eval(val uint32) bool {
-	if e.Op == OP_TRUE {
-		return true
+func (e *Expr) u32Eval(val uint32) Res {
+	if e.Op == OP_PRESENT {
+		return RES_TRUE
 	}
 	ref := e.Val.(uint32)
 	switch e.Op {
 	case OP_EQ:
-		return val == ref
+		return resBool(val == ref)
 	case OP_LT:
-		return val < ref
+		return resBool(val < ref)
 	case OP_LE:
-		return val <= ref
+		return resBool(val <= ref)
 	case OP_GT:
-		return val > ref
+		return resBool(val > ref)
 	case OP_GE:
-		return val >= ref
+		return resBool(val >= ref)
 	}
-	return false
+	return RES_FALSE
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/itlightning/dateparse v0.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/itlightning/dateparse v0.2.1 h1:AB0NJTyI0HYcerEUMovKZOiQVBg1mBPxgAnWQwzLP6g=
+github.com/itlightning/dateparse v0.2.1/go.mod h1:xHlmL8lT0L9JIBlaKotRwsoDYpKJskXpiU9ZwbbSkNA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -20,9 +20,10 @@ import (
 type Msg struct {
 	// internal
 
-	ref  bool   // true iff Data references memory we don't own
-	buf  []byte // internal buffer
-	json []byte // JSON representation (own memory), can be nil
+	ref    bool   // true iff Data references memory we don't own
+	buf    []byte // internal buffer
+	json   []byte // JSON representation (own memory), can be nil
+	jupper []byte // upper layer JSON (subslice of json), can be nil
 
 	// optional metadata
 
@@ -126,6 +127,7 @@ func (msg *Msg) Reset() *Msg {
 	} else {
 		msg.json = nil
 	}
+	msg.jupper = nil
 
 	return msg
 }
@@ -431,6 +433,7 @@ func (msg *Msg) GetJSON() []byte {
 	dst = append(dst, `",`...)
 
 	// [4] upper layer (optional)
+	up_from := len(dst)
 	switch msg.Upper {
 	case OPEN:
 		dst = msg.Open.ToJSON(dst)
@@ -445,6 +448,7 @@ func (msg *Msg) GetJSON() []byte {
 	default:
 		dst = json.Hex(dst, msg.Data)
 	}
+	up_till := len(dst)
 
 	// [5] value
 	dst = append(dst, ',')
@@ -456,7 +460,17 @@ func (msg *Msg) GetJSON() []byte {
 
 	// done!
 	msg.json = append(dst, "]\n"...)
+	msg.jupper = msg.json[up_from:up_till] // cache upper layer JSON for quick access
 	return msg.json
+}
+
+// UpperJSON returns the upper layer as JSON (element [4] of the message JSON array).
+func (msg *Msg) UpperJSON() []byte {
+	if len(msg.json) == 0 {
+		msg.jupper = nil // invalidate cached upper layer JSON
+		msg.GetJSON()    // regenerate both json and jupper
+	}
+	return msg.jupper
 }
 
 // ToJSON appends JSON representation of msg + "\n" to dst (may be nil to allocate)

--- a/msg/update.go
+++ b/msg/update.go
@@ -557,6 +557,15 @@ func (u *Update) LocalPref() (localpref uint32, ok bool) {
 	}
 }
 
+// Otc returns the ATTR_OTC value (Only To Customer, RFC 9234)
+func (u *Update) Otc() (otc uint32, ok bool) {
+	if a, ok := u.Attrs.Get(attrs.ATTR_OTC).(*attrs.U32); ok {
+		return a.Val, true
+	} else {
+		return 0, false
+	}
+}
+
 // Community returns the community attribute, or nil if not defined.
 func (u *Update) Community() *attrs.Community {
 	c, _ := u.Attrs.Get(attrs.ATTR_COMMUNITY).(*attrs.Community)


### PR DESCRIPTION
Add new filter attributes for flexible BGP message matching:
- json[path]: match arbitrary JSON paths in message upper layer
- attr[NAME]: shortcut for json[attrs.NAME.value] with attr name resolution
- time: timestamp string matching with regex and lexicographic comparison
- dir: message direction matching (L/R)
- seq: sequence number numeric comparison

Also fix != and !~ operators to require attribute existence — previously they matched when an attribute was absent (NOT false = true), now they only match when the attribute exists but its value differs.

Extract cmpOp() helper for three-way comparison reuse across seq, time, and json eval. Add AS_PATH segment helpers (AllASNs, Hops).