### PR TITLE
flowspec: fix value truncation in JSON numeric operators

### DIFF
--- a/attrs/flowspec_wire_test.go
+++ b/attrs/flowspec_wire_test.go
@@ -390,3 +390,29 @@ func TestMPFlowspec_JSON_Roundtrip(t *testing.T) {
 	fs2.Marshal(cps, dir.DIR_L)
 	require.True(t, bytes.Equal(mp.Data, mp2.Data))
 }
+
+// TestFlowGeneric_FromJSONLen tests that FromJSON derives the wire value
+// length from the value when no explicit "len" is given (issue found in
+// a JSON->wire->JSON round trip: 8000 was truncated to one byte = 64).
+func TestFlowGeneric_FromJSONLen(t *testing.T) {
+	var cps caps.Caps
+
+	fg := NewFlowGeneric(FLOW_PORT_DST).(*FlowGeneric)
+	src := `[{"op":">=","val":8000},{"and":true,"op":"<=","val":9000}]`
+	require.NoError(t, fg.FromJSON([]byte(src)))
+
+	// marshal to wire and parse back
+	wire := fg.Marshal(nil, cps)
+	fg2 := NewFlowGeneric(FLOW_PORT_DST).(*FlowGeneric)
+	_, err := fg2.Unmarshal(wire, cps)
+	require.NoError(t, err)
+
+	require.Equal(t, []uint64{8000, 9000}, fg2.Val)
+	require.JSONEq(t, src, string(fg2.ToJSON(nil)))
+
+	// explicit "len" still wins
+	fg3 := NewFlowGeneric(FLOW_PORT_DST).(*FlowGeneric)
+	require.NoError(t, fg3.FromJSON([]byte(`[{"op":"==","val":80,"len":2}]`)))
+	wire3 := fg3.Marshal(nil, cps)
+	require.Equal(t, []byte{0x91, 0x00, 0x50}, wire3) // last|len=2|==, val 80 in 2 bytes
+}

--- a/attrs/mp-flowspec.go
+++ b/attrs/mp-flowspec.go
@@ -704,6 +704,7 @@ func (f *FlowGeneric) FromJSON(src []byte) (err error) {
 		// parse op+val definition
 		var fop FlowOp
 		var fval uint64
+		var has_len bool
 		err := json.ObjectEach(val, func(key string, val []byte, typ json.Type) error {
 			switch key {
 			case "and":
@@ -753,6 +754,7 @@ func (f *FlowGeneric) FromJSON(src []byte) (err error) {
 				fval = val
 
 			case "len":
+				has_len = true
 				l, err := strconv.ParseUint(json.SQ(val), 10, 64)
 				if err != nil {
 					return err
@@ -778,6 +780,18 @@ func (f *FlowGeneric) FromJSON(src []byte) (err error) {
 		})
 		if err != nil {
 			return err
+		}
+
+		// derive the minimal value length, unless given explicitly
+		if !has_len {
+			switch {
+			case fval > 0xFFFFFFFF:
+				fop |= 0b11 << 4
+			case fval > 0xFFFF:
+				fop |= 0b10 << 4
+			case fval > 0xFF:
+				fop |= 0b01 << 4
+			}
 		}
 
 		// add to f, iterate to next (operator, value) element


### PR DESCRIPTION
## Summary
Found while verifying the flowspec docs with a JSON→wire→JSON round trip: numeric operator values above 255 were silently truncated on the wire, because `FromJSON` only sets the FLOW_OP_LEN bits when an explicit `len` key is present — which `ToJSON` never emits for numeric ops. A port range `8000-9000` marshaled as `64-40`.

Fix: derive the minimal RFC 8955 value length (1/2/4/8) from the value when `len` is absent; an explicit `len` still takes precedence.

## Test plan
- new `TestFlowGeneric_FromJSONLen`: JSON→wire→JSON round trip of the 8000-9000 range, plus explicit-len precedence
- full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)